### PR TITLE
Deadline dependent jobs

### DIFF
--- a/unreal/UnrealDeadlineService/Content/Python/deadline_command.py
+++ b/unreal/UnrealDeadlineService/Content/Python/deadline_command.py
@@ -132,9 +132,9 @@ class DeadlineCommand:
         proc.stderr.close()
 
         output = proc.stdout.read()
-        job_id = None
+        job_ids = []
         for line in output.decode("utf_8").split(os.linesep):
             if line.startswith("JobID"):
-                job_id = line.split("=")[1].strip()
-                break
-        return job_id
+                job_ids.append(line.split("=")[1].strip())
+
+        return min(job_ids)


### PR DESCRIPTION
Fixed an issue with deadline command where the job id returned is incorrect. Sometimes an automated system may create a dependent job. Deadline command will return both job id's however the function would return the wrong Id. Since deadline's job id's are incremental, when multiple id's are returned, the oldest or lowest job Id is the submitted job.