### PR TITLE
Reverting hard disabling of monitor submitter

### DIFF
--- a/deadline/plugins/UnrealEngine5/ue_utils/submit_deadline_job.py
+++ b/deadline/plugins/UnrealEngine5/ue_utils/submit_deadline_job.py
@@ -64,11 +64,8 @@ def submit_job(name, job_info, plugin_info, aux_files=None):
         for scene_file in aux_files:
             args.Add(scene_file)
 
-    if True:
-        results = "Submissions through the monitor are disabled for Unreal Engine 5 plugin"
-    else:
-        # Submit the job
-        results = ClientUtils.ExecuteCommandAndGetOutput(args)
+    # Submit the job
+    results = ClientUtils.ExecuteCommandAndGetOutput(args)
     
     # TODO: Return the Job ID and results
 


### PR DESCRIPTION
The monitor submitter was hard disabled during initial development. The submitter is by default hidden in the deadline monitor, so it is safe to remove the hard disabling