### PR TITLE
Updated conf.py and 03-api.rst so the docs build without errors

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,7 +6,7 @@ import os
 import sys
 
 # Code paths for documentation
-code_paths = ['../deadline/plugins/UnrealEngine',
+code_paths = ['../deadline/plugins/UnrealEngine5',
               '../unreal/UnrealDeadlineService/Content/Python',
               '../unreal/MoviePipelineDeadline/Content/Python']
 

--- a/docs/source/deadline/03-api.rst
+++ b/docs/source/deadline/03-api.rst
@@ -20,7 +20,7 @@ RPC
 Plugin
 ++++++
 
-.. automodule:: UnrealEngine
+.. automodule:: UnrealEngine5
    :members:
    :undoc-members:
    :show-inheritance:


### PR DESCRIPTION
The Deadline Plugins name was changed from "UnrealEngine" to "UnrealEngine5" - I added this change to the conf, so sphinx can built the docs without throwing errors and omitting the Deadline Python-API section